### PR TITLE
feat: allow optional MQTT authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ The integration will now appear like any standard Home Assistant integration.
    - ✅ **DNS redirection** (reroute Duux API calls to your local Broker) 
 
 2. In Home Assistant, go to `Settings > Devices & Services > Add Integration` and search for `Duux Fan Local`.
-3. Select your fan model from the list.
-4. Give your device a friendly name.
-5. Enter the **MAC address** of your Duux fan
-   > 💡 You can find it in your router’s connected devices list.
-6. Click **Submit** and enjoy local control of your fan!
+3. Choose whether to connect to your MQTT broker anonymously or with credentials.
+4. If using credentials, enter your MQTT **username** and **password**.
+5. Provide a friendly name, the **MAC address** of your Duux fan, and select its model
+   > 💡 You can find the MAC in your router’s connected devices list.
+6. Click **Submit** to test the connection and finish the setup!
 
 ### Screenshots
 

--- a/custom_components/duux_fan_local/config_flow.py
+++ b/custom_components/duux_fan_local/config_flow.py
@@ -11,11 +11,24 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import DOMAIN, CONF_DEVICE_ID, CONF_MODEL, MODELS, MQTT_HOST, MQTT_PORT, MQTT_TIMEOUT, TOPIC_STATE
+from .const import (
+    DOMAIN,
+    CONF_DEVICE_ID,
+    CONF_MODEL,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    MODELS,
+    MQTT_HOST,
+    MQTT_PORT,
+    MQTT_TIMEOUT,
+    TOPIC_STATE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
-def test_connection(device_id: str) -> bool:
+def test_connection(
+    device_id: str, username: str | None = None, password: str | None = None
+) -> bool:
     """Tests the connection to the Duux MQTT broker by listening for a message."""
     import paho.mqtt.client as mqtt
 
@@ -33,6 +46,9 @@ def test_connection(device_id: str) -> bool:
     client = mqtt.Client()
     client.on_connect = on_connect
     client.on_message = on_message
+
+    if username or password:
+        client.username_pw_set(username, password)
 
     client.tls_set(cert_reqs=ssl.CERT_NONE)
 
@@ -58,37 +74,97 @@ class DuuxFanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Duux Fan."""
 
     VERSION = 1
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
 
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Redirect to the connection step."""
+        return await self.async_step_connection(user_input)
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_connection(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Choose between anonymous or credentialed connection."""
+        if user_input is not None:
+            if user_input["connection_type"] == "credentials":
+                return await self.async_step_credentials()
+            self._data = {}
+            return await self.async_step_device()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required("connection_type", default="anonymous"): vol.In(
+                    {
+                        "anonymous": "Anonymous",
+                        "credentials": "Username and password",
+                    }
+                )
+            }
+        )
+
+        return self.async_show_form(step_id="connection", data_schema=data_schema)
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Collect MQTT credentials."""
+        if user_input is not None:
+            self._data[CONF_USERNAME] = user_input[CONF_USERNAME]
+            self._data[CONF_PASSWORD] = user_input[CONF_PASSWORD]
+            return await self.async_step_device()
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): str,
+                vol.Required(CONF_PASSWORD): str,
+            }
+        )
+
+        return self.async_show_form(step_id="credentials", data_schema=data_schema)
+
+    async def async_step_device(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure fan details and test connection."""
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            # Convert MAC address to lowercase
             user_input[CONF_DEVICE_ID] = user_input[CONF_DEVICE_ID].lower()
 
             await self.async_set_unique_id(user_input[CONF_DEVICE_ID])
             self._abort_if_unique_id_configured()
 
             is_connected = await self.hass.async_add_executor_job(
-                test_connection, user_input[CONF_DEVICE_ID]
+                test_connection,
+                user_input[CONF_DEVICE_ID],
+                self._data.get(CONF_USERNAME),
+                self._data.get(CONF_PASSWORD),
             )
 
             if is_connected:
+                self._data.update(
+                    {
+                        CONF_NAME: user_input[CONF_NAME],
+                        CONF_DEVICE_ID: user_input[CONF_DEVICE_ID],
+                        CONF_MODEL: user_input[CONF_MODEL],
+                    }
+                )
                 return self.async_create_entry(
-                    title=user_input[CONF_NAME], data=user_input
+                    title=self._data[CONF_NAME], data=self._data
                 )
 
             errors["base"] = "cannot_connect"
 
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_MODEL): vol.In(MODELS),
                 vol.Required(CONF_NAME): str,
                 vol.Required(CONF_DEVICE_ID): str,
+                vol.Required(CONF_MODEL): vol.In(MODELS),
             }
         )
 
         return self.async_show_form(
-            step_id="user", data_schema=data_schema, errors=errors
+            step_id="device", data_schema=data_schema, errors=errors
         )

--- a/custom_components/duux_fan_local/const.py
+++ b/custom_components/duux_fan_local/const.py
@@ -3,6 +3,8 @@ DOMAIN = "duux_fan_local"
 # Configuration keys
 CONF_DEVICE_ID = "device_id"
 CONF_MODEL = "model"
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
 MANUFACTURER = "Duux"
 MODELS = {
     "whisper_flex_1": "Whisper Flex 1",

--- a/custom_components/duux_fan_local/mqtt.py
+++ b/custom_components/duux_fan_local/mqtt.py
@@ -8,6 +8,8 @@ from homeassistant.core import HomeAssistant
 
 from .const import (
     CONF_DEVICE_ID,
+    CONF_PASSWORD,
+    CONF_USERNAME,
     MQTT_HOST,
     MQTT_PORT,
     TOPIC_COMMAND,
@@ -30,6 +32,8 @@ class DuuxMqttClient:
         self._client = mqtt.Client()
         self._client.on_connect = self.on_connect
         self._client.on_message = self.on_message
+        self._username = config.get(CONF_USERNAME)
+        self._password = config.get(CONF_PASSWORD)
 
     async def async_connect(self):
         """Asynchronously configure TLS and connect to the MQTT broker."""
@@ -37,6 +41,8 @@ class DuuxMqttClient:
 
         def configure_tls_and_connect():
             self._client.tls_set(cert_reqs=ssl.CERT_NONE)
+            if self._username or self._password:
+                self._client.username_pw_set(self._username, self._password)
             self._client.connect(MQTT_HOST, MQTT_PORT, 60)
 
         try:

--- a/custom_components/duux_fan_local/translations/en.json
+++ b/custom_components/duux_fan_local/translations/en.json
@@ -1,12 +1,27 @@
 {
     "config": {
         "step": {
-            "user": {
-                "title": "Add a Duux Fan",
+            "connection": {
+                "title": "MQTT Connection",
                 "data": {
-                    "model": "Fan Model",
+                    "connection_type": "Connection type",
+                    "anonymous": "Anonymous",
+                    "credentials": "Username and password"
+                }
+            },
+            "credentials": {
+                "title": "MQTT Credentials",
+                "data": {
+                    "username": "MQTT Username",
+                    "password": "MQTT Password"
+                }
+            },
+            "device": {
+                "title": "Configure Duux Fan",
+                "data": {
                     "name": "Name",
-                    "device_id": "Identifier (MAC)"
+                    "device_id": "Identifier (MAC)",
+                    "model": "Fan Model"
                 },
                 "data_description": {
                     "name": "Example: Living Room Fan",

--- a/custom_components/duux_fan_local/translations/es.json
+++ b/custom_components/duux_fan_local/translations/es.json
@@ -1,12 +1,27 @@
 {
     "config": {
         "step": {
-            "user": {
-                "title": "Agregar un ventilador Duux",
+            "connection": {
+                "title": "Conexión MQTT",
                 "data": {
-                    "model": "Modelo del ventilador",
+                    "connection_type": "Tipo de conexión",
+                    "anonymous": "Anónima",
+                    "credentials": "Nombre de usuario y contraseña"
+                }
+            },
+            "credentials": {
+                "title": "Credenciales MQTT",
+                "data": {
+                    "username": "Nombre de usuario MQTT",
+                    "password": "Contraseña MQTT"
+                }
+            },
+            "device": {
+                "title": "Configurar ventilador Duux",
+                "data": {
                     "name": "Nombre",
-                    "device_id": "Identificador (MAC)"
+                    "device_id": "Identificador (MAC)",
+                    "model": "Modelo del ventilador"
                 },
                 "data_description": {
                     "name": "Ejemplo: Ventilador del salón",

--- a/custom_components/duux_fan_local/translations/fr.json
+++ b/custom_components/duux_fan_local/translations/fr.json
@@ -1,12 +1,27 @@
 {
     "config": {
         "step": {
-            "user": {
-                "title": "Ajouter un ventilateur Duux",
+            "connection": {
+                "title": "Connexion MQTT",
                 "data": {
-                    "model": "Modèle du ventilateur",
+                    "connection_type": "Type de connexion",
+                    "anonymous": "Anonyme",
+                    "credentials": "Nom d'utilisateur et mot de passe"
+                }
+            },
+            "credentials": {
+                "title": "Identifiants MQTT",
+                "data": {
+                    "username": "Nom d'utilisateur MQTT",
+                    "password": "Mot de passe MQTT"
+                }
+            },
+            "device": {
+                "title": "Configurer le ventilateur Duux",
+                "data": {
                     "name": "Nom",
-                    "device_id": "Identifiant (MAC)"
+                    "device_id": "Identifiant (MAC)",
+                    "model": "Modèle du ventilateur"
                 },
                 "data_description": {
                     "name": "Exemple : Ventilateur Salon",


### PR DESCRIPTION
## Summary
- allow providing MQTT credentials during setup
- choose between anonymous and authenticated broker connections before configuring the fan
- document updated setup flow in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f5200f6b8832d8acbf6559b813f77