### PR TITLE
Add a use_tls toggle to support connecting to a local broker bridged to the Duux MQTT broker

### DIFF
--- a/custom_components/duux_fan_local/config_flow.py
+++ b/custom_components/duux_fan_local/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     CONF_MODEL,
     CONF_MQTT_HOST,
     CONF_MQTT_PORT,
+    CONF_USE_TLS,
     MODELS,
     MQTT_HOST,
     MQTT_PORT,
@@ -33,7 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def test_broker_connection(
-    username: str | None, password: str | None, host: str, port: int
+    username: str | None, password: str | None, host: str, port: int, use_tls: bool = True
 ) -> bool:
     """Test connection to the MQTT broker."""
     import paho.mqtt.client as mqtt
@@ -41,7 +42,8 @@ def test_broker_connection(
     client = mqtt.Client()
     if username:
         client.username_pw_set(username, password)
-    client.tls_set(cert_reqs=ssl.CERT_NONE)
+    if use_tls:
+        client.tls_set(cert_reqs=ssl.CERT_NONE)
     try:
         client.connect(host, port, 60)
         client.disconnect()
@@ -68,6 +70,7 @@ class MqttCredentials:
     password: str | None = None
     host: str = MQTT_HOST
     port: int = MQTT_PORT
+    use_tls: bool = True
 
 
 def test_device_connection(credentials: MqttCredentials) -> bool:
@@ -90,8 +93,8 @@ def test_device_connection(credentials: MqttCredentials) -> bool:
         client.username_pw_set(credentials.username, credentials.password)
     client.on_connect = on_connect
     client.on_message = on_message
-
-    client.tls_set(cert_reqs=ssl.CERT_NONE)
+    if credentials.use_tls:
+        client.tls_set(cert_reqs=ssl.CERT_NONE)
 
     try:
         client.connect(credentials.host, credentials.port, 60)
@@ -124,6 +127,7 @@ class DuuxFanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._password: str | None = None
         self._mqtt_host: str = MQTT_HOST
         self._mqtt_port: int = MQTT_PORT
+        self._use_tls: bool = True
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -136,6 +140,7 @@ class DuuxFanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self._password = user_input.get(CONF_PASSWORD)
             self._mqtt_host = user_input.get(CONF_MQTT_HOST, MQTT_HOST)
             self._mqtt_port = user_input.get(CONF_MQTT_PORT, MQTT_PORT)
+            self._use_tls = user_input.get(CONF_USE_TLS, True)
 
             is_connected = await self.hass.async_add_executor_job(
                 test_broker_connection,
@@ -143,6 +148,7 @@ class DuuxFanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._password,
                 self._mqtt_host,
                 self._mqtt_port,
+                self._use_tls,
             )
 
             if is_connected:
@@ -156,6 +162,7 @@ class DuuxFanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Optional(CONF_PASSWORD): str,
                 vol.Optional(CONF_MQTT_HOST, default=MQTT_HOST): str,
                 vol.Optional(CONF_MQTT_PORT, default=MQTT_PORT): int,
+                vol.Optional(CONF_USE_TLS, default=True): bool,
             }
         )
 
@@ -175,12 +182,18 @@ class DuuxFanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_DEVICE_ID])
             self._abort_if_unique_id_configured()
 
+            # For local broker (no TLS), skip the device-message wait — the broker
+            # accepts the connection but won't have messages during setup.
+            if not self._use_tls:
+                return self._create_device_entry(user_input)
+
             credentials = MqttCredentials(
                 device_id=user_input[CONF_DEVICE_ID],
                 username=self._username,
                 password=self._password,
                 host=self._mqtt_host,
                 port=self._mqtt_port,
+                use_tls=self._use_tls,
             )
 
             is_connected = await self.hass.async_add_executor_job(
@@ -213,6 +226,7 @@ class DuuxFanConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_DEVICE_ID: user_input[CONF_DEVICE_ID],
             CONF_MQTT_HOST: self._mqtt_host,
             CONF_MQTT_PORT: self._mqtt_port,
+            CONF_USE_TLS: self._use_tls,
         }
         if self._username:
             data[CONF_USERNAME] = self._username

--- a/custom_components/duux_fan_local/const.py
+++ b/custom_components/duux_fan_local/const.py
@@ -7,6 +7,7 @@ CONF_DEVICE_ID = "device_id"
 CONF_MODEL = "model"
 CONF_MQTT_HOST = "mqtt_host"
 CONF_MQTT_PORT = "mqtt_port"
+CONF_USE_TLS = "use_tls"
 MANUFACTURER = "Duux"
 
 # Generate MODELS dynamically from DEVICE_PROFILES

--- a/custom_components/duux_fan_local/mqtt.py
+++ b/custom_components/duux_fan_local/mqtt.py
@@ -16,6 +16,7 @@ from .const import (
     CONF_DEVICE_ID,
     CONF_MQTT_HOST,
     CONF_MQTT_PORT,
+    CONF_USE_TLS,
     MQTT_HOST,
     MQTT_PORT,
     TOPIC_COMMAND,
@@ -40,8 +41,10 @@ class DuuxMqttClient:
         self._password = config.get(CONF_PASSWORD)
         self._mqtt_host = config.get(CONF_MQTT_HOST, MQTT_HOST)
         self._mqtt_port = config.get(CONF_MQTT_PORT, MQTT_PORT)
+        self._use_tls = config.get(CONF_USE_TLS, True)
         self._callbacks = []
         self._client = mqtt.Client()
+        self._client.reconnect_delay_set(min_delay=5, max_delay=60)
         self._client.on_connect = self.on_connect
         self._client.on_message = self.on_message
 
@@ -52,7 +55,8 @@ class DuuxMqttClient:
         def configure_tls_and_connect():
             if self._username:
                 self._client.username_pw_set(self._username, self._password)
-            self._client.tls_set(cert_reqs=ssl.CERT_NONE)
+            if self._use_tls:
+                self._client.tls_set(cert_reqs=ssl.CERT_NONE)
             self._client.connect(self._mqtt_host, self._mqtt_port, 60)
 
         try:

--- a/custom_components/duux_fan_local/translations/en.json
+++ b/custom_components/duux_fan_local/translations/en.json
@@ -8,13 +8,15 @@
                     "username": "MQTT Username",
                     "password": "MQTT Password",
                     "mqtt_host": "MQTT Host",
-                    "mqtt_port": "MQTT Port"
+                    "mqtt_port": "MQTT Port",
+                    "use_tls": "Use TLS"
                 },
                 "data_description": {
                     "username": "Leave empty to connect anonymously.",
                     "password": "Leave empty to connect anonymously.",
                     "mqtt_host": "Leave as default unless you need to modify it.",
-                    "mqtt_port": "Leave as default unless you need to modify it."
+                    "mqtt_port": "Leave as default unless you need to modify it.",
+                    "use_tls": "Disable for a local broker without TLS."
                 }
             },
             "device": {


### PR DESCRIPTION
Adds an optional Use TLS toggle so the integration can connect to a local HA MQTT broker that is already bridged to the Duux cloud broker.