### PR TITLE
Add Whisper Flex Ultimate device profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This integration uses a flexible Device Profile architecture designed to easily 
 **Currently officially supported:**
 - **Duux Whisper Flex** (Fan)
 - **Duux Whisper Flex 2** (Fan)
+- **Duux Whisper Flex Ultimate** (Fan)
 - **Duux Bright 2** (Air Purifier)
 
 
@@ -135,6 +136,18 @@ Unplug → remove the battery (if applicable) → wait ~1 second → reinsert �
 | **Child Lock**      | `lock`   | `tune set lock X`   | `0`: off, `1`: on                      |
 | **Battery Level**   | `batlvl` | N/A                 | `0` to `10`                            |
 | **Charging Status** | `batcha` | N/A                 | `0`: not charging , `1`: charging      |
+
+### Whisper Flex Ultimate
+
+| Feature             |   Key    | Command Payload     | Value X=                                          |
+|---------------------|----------|---------------------|---------------------------------------------------|
+| **Power**           | `power`  | `tune set power X`  | `0`: off, `1`: on                                 |
+| **Mode**            | `mode`   | `tune set mode X`   | `0`: regular, `1`: natural, `2`: night            |
+| **Speed**           | `speed`  | `tune set speed X`  | `1` to `30`                                       |
+| **Timer**           | `timer`  | `tune set timer X`  | `0` to `12` hours                                 |
+| **Horizontal Osc.** | `swing`  | `tune set swing X`  | `0`: off, `1`: 30°, `2`: 60°, `3`: 90°           |
+| **Vertical Osc.**   | `tilt`   | `tune set tilt X`   | `0`: off, `1`: 90°, `2`: 105°                    |
+| **Setpoint**        | `sp`     | `tune set sp X`     | `17` to `28` °C                                   |
 
 ### Duux Bright 2
 | Feature             |   Key    | Command Payload     | Value X=                               |

--- a/custom_components/duux_fan_local/devices.py
+++ b/custom_components/duux_fan_local/devices.py
@@ -23,6 +23,7 @@ ATTR_HOR_OSC = "horosc"
 ATTR_VER_OSC = "verosc"
 ATTR_SWING = "swing"
 ATTR_TILT = "tilt"
+ATTR_SETPOINT = "sp"
 # Air purifier attributes
 ATTR_FILTER = "filter"
 ATTR_PPM = "ppm"
@@ -269,6 +270,71 @@ DEVICE_PROFILES = {
                 "icon": "mdi:battery-charging",
             }
         },
+    },
+    "whisper_flex_ultimate": {
+        "name": "Whisper Flex Ultimate",
+        "fan": {
+            "supported_features": ["turn_on", "turn_off", "set_speed"],
+            "max_speed": 30,
+        },
+        "switches": {},
+        "sensors": {},
+        "numbers": {
+            "speed": {
+                "name": "Speed",
+                "command_topic": "tune set speed",
+                "state_key": ATTR_SPEED,
+                "min": 1.0,
+                "max": 30.0,
+                "step": 1.0,
+                "unit": None,
+                "icon": "mdi:speedometer",
+            },
+            "timer": {
+                "name": "Timer",
+                "command_topic": "tune set timer",
+                "state_key": ATTR_TIMER,
+                "min": 0.0,
+                "max": 12.0,
+                "step": 1.0,
+                "unit": "h",
+                "icon": "mdi:timer-outline",
+            },
+            "setpoint": {
+                "name": "Setpoint",
+                "command_topic": "tune set sp",
+                "state_key": ATTR_SETPOINT,
+                "min": 17.0,
+                "max": 28.0,
+                "step": 1.0,
+                "unit": "°C",
+                "icon": "mdi:thermometer",
+            },
+        },
+        "select": {
+            "fan_mode": {
+                "name": "Fan Mode",
+                "command_topic": "tune set mode",
+                "state_key": ATTR_MODE,
+                "options": {"Regular": 0, "Natural": 1, "Night": 2},
+                "icon": "mdi:weather-windy",
+            },
+            "swing": {
+                "name": "Swing",
+                "command_topic": "tune set swing",
+                "state_key": ATTR_SWING,
+                "options": {"Off": 0, "30°": 1, "60°": 2, "90°": 3},
+                "icon": "mdi:arrow-left-right",
+            },
+            "tilt": {
+                "name": "Tilt",
+                "command_topic": "tune set tilt",
+                "state_key": ATTR_TILT,
+                "options": {"Off": 0, "90°": 1, "105°": 2},
+                "icon": "mdi:arrow-up-down",
+            },
+        },
+        "binary_sensors": {},
     },
     "bright_2": {
         "name": "Duux Bright 2",


### PR DESCRIPTION
Adds support for the Whisper Flex Ultimate, including speed (1–30), fan modes (Regular/Natural/Night), swing (Off/30°/60°/90°), tilt (Off/90°/105°), timer, and temperature setpoint.